### PR TITLE
add whitelist for ReStock

### DIFF
--- a/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.restockwhitelist
+++ b/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.restockwhitelist
@@ -1,0 +1,1 @@
+Squad/Parts/Aero/fairings/fairingSize2.mu


### PR DESCRIPTION
One affected entry:
Squad/Parts/Aero/fairings/fairingSize2 (.mu)