### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version
+++ b/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version
@@ -1,7 +1,7 @@
 {
   "NAME"     : "Procedural Fairings - For Everything!",
   "DOWNLOAD" : "https://github.com/KSP-RO/ProceduralFairings-ForEverything/releases",
-  "URL"      : "https://raw.githubusercontent.com/KSP-RO/ProceduralFairings-ForEverything/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version",
+  "URL"      : "https://github.com/KSP-RO/ProceduralFairings-ForEverything/raw/master/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version",
   "GITHUB" : {
       "USERNAME"   : "KSP-RO",
       "REPOSITORY" : "ProceduralFairings-ForEverything"


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

Tagging @pap1723 to make sure GitHub sends a notification.

https://github.com/DasSkelett/AVC-VersionFileValidator by @DasSkelett is great for catching things like this in advance.